### PR TITLE
Goptr errors

### DIFF
--- a/falcon.go
+++ b/falcon.go
@@ -149,11 +149,13 @@ func (pk *PublicKey) Verify(signature CompressedSignature, msg []byte) error {
 // VerifyCTSignature reports whether sig is a valid CT-format signature of msg under publicKey.
 // It outputs nil if so, and an error otherwise.
 func (pk *PublicKey) VerifyCTSignature(signature CTSignature, msg []byte) error {
-	data := C.NULL
+	var r C.int
 	if len(msg) > 0 {
-		data = unsafe.Pointer(&msg[0])
+		r = C.falcon_det1024_verify_ct(unsafe.Pointer(&signature[0]), unsafe.Pointer(&(*pk)), unsafe.Pointer(&msg[0]), C.size_t(len(msg)))
+	} else {
+		r = C.falcon_det1024_verify_ct(unsafe.Pointer(&signature[0]), unsafe.Pointer(&(*pk)), C.NULL, C.size_t(len(msg)))
 	}
-	r := C.falcon_det1024_verify_ct(unsafe.Pointer(&signature[0]), unsafe.Pointer(&(*pk)), data, C.size_t(len(msg)))
+
 	if r != 0 {
 		return fmt.Errorf("error code %d: %w", int(r), ErrVerifyFail)
 	}

--- a/falcon.go
+++ b/falcon.go
@@ -74,7 +74,7 @@ func GenerateKey(seed []byte) (PublicKey, PrivateKey, error) {
 	if seedLen := len(seed); seedLen > 0 {
 		C.shake256_init_prng_from_seed(&rng, unsafe.Pointer(&seed[0]), C.size_t(seedLen))
 	} else {
-		C.shake256_init_prng_from_seed(&rng, (unsafe.Pointer)(C.NULL), C.size_t(seedLen))
+		C.shake256_init_prng_from_seed(&rng, C.NULL, C.size_t(seedLen))
 	}
 
 	publicKey := PublicKey{}

--- a/falcon.go
+++ b/falcon.go
@@ -71,13 +71,11 @@ type CTSignature [CTSignatureSize]byte
 // GenerateKey generates a public/private key pair from the given seed.
 func GenerateKey(seed []byte) (PublicKey, PrivateKey, error) {
 	var rng C.shake256_context
-
-	seedLen := len(seed)
-	seedData := (*C.uchar)(C.NULL)
-	if seedLen > 0 {
-		seedData = (*C.uchar)(&seed[0])
+	if seedLen := len(seed); seedLen > 0 {
+		C.shake256_init_prng_from_seed(&rng, unsafe.Pointer(&seed[0]), C.size_t(seedLen))
+	} else {
+		C.shake256_init_prng_from_seed(&rng, (unsafe.Pointer)(C.NULL), C.size_t(seedLen))
 	}
-	C.shake256_init_prng_from_seed(&rng, unsafe.Pointer(seedData), C.size_t(seedLen))
 
 	publicKey := PublicKey{}
 	privateKey := PrivateKey{}


### PR DESCRIPTION
Using multiple pointer variables might lead to panic with the following error: "cgo argument has Go pointer to Go pointer". 
in this PR, I'm attempting to reduce the amount of Go Pointer to Go Pointer variables in the code. 