### PR TITLE
Add functions for computing auxiliary Falcon values (h,c,s1,s2)

### DIFF
--- a/deterministic.c
+++ b/deterministic.c
@@ -174,7 +174,7 @@ int falcon_det1024_pubkey_coeffs(uint16_t *h, const void *pubkey) {
 	/*
 	 * Decode public key.
 	 */
-	if (Zf(modq_decode)(h, FALCON_DET1024_LOGN, pubkey + 1, FALCON_DET1024_PUBKEY_SIZE - 1)
+	if (Zf(modq_decode)(h, FALCON_DET1024_LOGN, (uint8_t*)pubkey + 1, FALCON_DET1024_PUBKEY_SIZE - 1)
 		!= FALCON_DET1024_PUBKEY_SIZE - 1)
 	{
 		return FALCON_ERR_FORMAT;
@@ -205,7 +205,7 @@ int falcon_det1024_s2_coeffs(int16_t *s2, const void* sig) {
 		return FALCON_ERR_FORMAT;
 	}
 
-	int v = Zf(trim_i16_decode)(s2, logn, Zf(max_sig_bits)[logn], sig+2, FALCON_DET1024_SIG_CT_SIZE-2);
+	size_t v = Zf(trim_i16_decode)(s2, logn, Zf(max_sig_bits)[logn], (uint8_t*)sig+2, FALCON_DET1024_SIG_CT_SIZE-2);
 	if (v != FALCON_DET1024_SIG_CT_SIZE-2) {
 		return FALCON_ERR_FORMAT;
 	}

--- a/deterministic.h
+++ b/deterministic.h
@@ -119,6 +119,50 @@ int falcon_det1024_convert_compressed_to_ct(void *sig_ct,
  */
 int falcon_det1024_get_salt_version(const void* sig);
 
+/*
+ * Unpack a det1024 public key representing a ring element h to its
+ * vector of polynomial coefficients, i.e.,
+ *
+ * h(x) = h[0] + h[1] * x + h[2] * x^2 + ... + h[1023] * x^1023.
+ *
+ * Returns a non-zero error code if pubkey is invalid.
+ */
+int falcon_det1024_pubkey_coeffs(uint16_t *h, const void *pubkey);
+
+/*
+ * Hash data of length data_len, using the fixed 40-byte salt
+ * specified by salt_version, to a ring element c, represented by
+ * its vector of polynomial coefficients.
+ *
+ * (See Section 3.7 of the Falcon specification for the details of the
+ *  hashing, and Section 2.3.2-3 of the Deterministic Falcon
+ *  specification for the definition of the fixed salt.)
+ */
+void falcon_det1024_hash_to_point_coeffs(uint16_t *c, const void *data, size_t data_len, uint8_t salt_version);
+
+/*
+ * Unpack a det1024 signature in CT format to the vector of polynomial
+ * coefficients of the associated ring element s_2.
+ *
+ * (See Section 3.10 of the Falcon specification for details.)
+ *
+ * Returns a non-zero error code if sig cannot be properly unpacked.
+ */
+int falcon_det1024_s2_coeffs(int16_t *s2, const void* sig);
+
+/*
+ * Compute the vector of polynomial coefficients of s_1 = c - s_2 * h,
+ * given the unpacked values h, c, and s_2.
+ *
+ * (See Section 3.10 of the Falcon specification for details.)
+ *
+ * Returns a non-zero error code if the aggregate (s_1,s_2) vector is
+ * not short enough to constitute a valid signature (for the public
+ * key corresponding to h, the hash digest corresponding to c, and the
+ * signature corresponding to s_2).
+ */
+int falcon_det1024_s1_coeffs(int16_t *s1, const uint16_t *h, const uint16_t *c, const int16_t *s2);
+
 #ifdef __cplusplus
 }
 #endif

--- a/falcon.go
+++ b/falcon.go
@@ -52,6 +52,8 @@ const (
 	CTSignatureSize = C.FALCON_DET1024_SIG_CT_SIZE
 	// SignatureMaxSize is the max possible size in bytes of a Falcon signature in compressed format.
 	SignatureMaxSize = C.FALCON_DET1024_SIG_COMPRESSED_MAXSIZE
+	// N=1024 is the degree of Falcon det1024 polynomials.
+	N = 1 << C.FALCON_DET1024_LOGN
 )
 
 // PublicKey represents a falcon public key
@@ -179,9 +181,6 @@ func (sig CompressedSignature) SaltVersion() byte {
 func (sig *CTSignature) SaltVersion() byte {
 	return sig[1]
 }
-
-// N=1024 is the degree of Falcon det1024 polynomials.
-const N = 1 << C.FALCON_DET1024_LOGN
 
 // Coefficients unpacks a public key representing a ring element h to its vector
 // of polynomial coefficients, i.e.,

--- a/falcon.go
+++ b/falcon.go
@@ -188,8 +188,8 @@ func (sig *CTSignature) SaltVersion() byte {
 // h(x) = h[0] + h[1] * x + h[2] * x^2 + ... + h[1023] * x^1023.
 //
 // Returns an error if pubkey is invalid.
-func (pub PublicKey) Coefficients() (h [N]uint16, err error) {
-	r := C.falcon_det1024_pubkey_coeffs((*C.uint16_t)(&h[0]), unsafe.Pointer(&pub[0]))
+func (pub *PublicKey) Coefficients() (h [N]uint16, err error) {
+	r := C.falcon_det1024_pubkey_coeffs((*C.uint16_t)(&h[0]), unsafe.Pointer(pub))
 	if r != 0 {
 		err = fmt.Errorf("falcon_det1024_pubkey_coeffs failed: %d", r)
 	}
@@ -200,8 +200,8 @@ func (pub PublicKey) Coefficients() (h [N]uint16, err error) {
 // coefficients of the associated ring element s_2. See Section 3.10 of the
 // Falcon specification for details. Returns an error if sig cannot be properly
 // unpacked.
-func (sig CTSignature) S2Coefficients() (s2 [N]int16, err error) {
-	r := C.falcon_det1024_s2_coeffs((*C.int16_t)(&s2[0]), unsafe.Pointer(&sig[0]))
+func (sig *CTSignature) S2Coefficients() (s2 [N]int16, err error) {
+	r := C.falcon_det1024_s2_coeffs((*C.int16_t)(&s2[0]), unsafe.Pointer(sig))
 	if r != 0 {
 		err = fmt.Errorf("falcon_det1024_s2_coeffs failed: %d", r)
 	}

--- a/falcon.go
+++ b/falcon.go
@@ -38,6 +38,10 @@ var (
 	ErrSignFail    = errors.New("falcon sign failed")
 	ErrVerifyFail  = errors.New("falcon verify failed")
 	ErrConvertFail = errors.New("falcon convert to CT failed")
+
+	ErrPubkeyCoefficientsFail = errors.New("falcon pubkey coefficients failed")
+	ErrS1CoefficientsFail     = errors.New("falcon computing S1 coefficients failed")
+	ErrS2CoefficientsFail     = errors.New("falcon computing S2 coefficients failed")
 )
 
 const (
@@ -191,7 +195,7 @@ func (sig *CTSignature) SaltVersion() byte {
 func (pub *PublicKey) Coefficients() (h [N]uint16, err error) {
 	r := C.falcon_det1024_pubkey_coeffs((*C.uint16_t)(&h[0]), unsafe.Pointer(pub))
 	if r != 0 {
-		err = fmt.Errorf("falcon_det1024_pubkey_coeffs failed: %d", r)
+		err = fmt.Errorf("error code %d: %w", int(r), ErrPubkeyCoefficientsFail)
 	}
 	return
 }
@@ -203,7 +207,7 @@ func (pub *PublicKey) Coefficients() (h [N]uint16, err error) {
 func (sig *CTSignature) S2Coefficients() (s2 [N]int16, err error) {
 	r := C.falcon_det1024_s2_coeffs((*C.int16_t)(&s2[0]), unsafe.Pointer(sig))
 	if r != 0 {
-		err = fmt.Errorf("falcon_det1024_s2_coeffs failed: %d", r)
+		err = fmt.Errorf("error code %d: %w", int(r), ErrS2CoefficientsFail)
 	}
 	return
 }
@@ -217,7 +221,7 @@ func (sig *CTSignature) S2Coefficients() (s2 [N]int16, err error) {
 func S1Coefficients(h [N]uint16, c [N]uint16, s2 [N]int16) (s1 [N]int16, err error) {
 	r := C.falcon_det1024_s1_coeffs((*C.int16_t)(&s1[0]), (*C.uint16_t)(&h[0]), (*C.uint16_t)(&c[0]), (*C.int16_t)(&s2[0]))
 	if r != 0 {
-		err = fmt.Errorf("falcon_det1024_s1_coeffs failed: %d", r)
+		err = fmt.Errorf("error code %d: %w", int(r), ErrS1CoefficientsFail)
 	}
 	return
 }

--- a/falcon.go
+++ b/falcon.go
@@ -228,7 +228,7 @@ func S1Coefficients(h [N]uint16, c [N]uint16, s2 [N]int16) (s1 [N]int16, err err
 // coefficients. See Section 3.7 of the Falcon specification for the details of the
 // hashing, and Section 2.3.2-3 of the Deterministic Falcon specification for
 // the definition of the fixed salt.
-func HashToPointCoefficients(msg []byte, saltVersion uint8) (c [N]uint16) {
+func HashToPointCoefficients(msg []byte, saltVersion byte) (c [N]uint16) {
 	data := C.NULL
 	if len(msg) > 0 {
 		data = unsafe.Pointer(&msg[0])

--- a/falcon_test.go
+++ b/falcon_test.go
@@ -138,7 +138,7 @@ func TestFalcon(t *testing.T) {
 		if err != nil {
 			t.Fatalf("pubkey coefficients failed: %s", err)
 		}
-		c := HashToPointCoefficients(msg, uint8(sigCT.SaltVersion()))
+		c := HashToPointCoefficients(msg, sigCT.SaltVersion())
 		s2, err := sigCT.S2Coefficients()
 		if err != nil {
 			t.Fatalf("s2 coefficients failed: %s", err)

--- a/falcon_test.go
+++ b/falcon_test.go
@@ -133,6 +133,21 @@ func TestFalcon(t *testing.T) {
 		if err != nil {
 			t.Fatalf("verify_ct failed err msg %s on pk: %v , sk: %v, msg: %v", err, pub, priv, msg)
 		}
+
+		h, err := pub.Coefficients()
+		if err != nil {
+			t.Fatalf("pubkey coefficients failed: %s", err)
+		}
+		c := HashToPointCoefficients(msg, uint8(sigCT.SaltVersion()))
+		s2, err := sigCT.S2Coefficients()
+		if err != nil {
+			t.Fatalf("s2 coefficients failed: %s", err)
+		}
+		s1, err := S1Coefficients(h, c, s2)
+		if err != nil {
+			t.Fatalf("s1 coefficients failed: %s", err)
+		}
+		_ = s1
 	}
 }
 

--- a/inner.h
+++ b/inner.h
@@ -1161,6 +1161,35 @@ int Zf(sampler)(void *ctx, fpr mu, fpr isigma);
 TARGET_AVX2
 int Zf(gaussian0_sampler)(prng *p);
 
+/*
+ * Compute NTT on a ring element.
+ */
+void Zf(mq_NTT)(uint16_t *a, unsigned logn);
+
+/*
+ * Compute the inverse NTT on a ring element.
+ */
+void Zf(mq_iNTT)(uint16_t *a, unsigned logn);
+
+/*
+ * Multiply two ring elements in NTT representation, and using a
+ * Montgomery multiplication. The result f*g is written over f.
+ */
+void Zf(mq_poly_montymul_ntt)(uint16_t *f, const uint16_t *g, unsigned logn);
+
+/*
+ * Subtract polynomial g from polynomial f, modulo q. Result f-g is
+ * written over f. Operands must be in the 0..q-1 range, as is the
+ * result.
+ */
+void Zf(mq_poly_sub)(uint16_t *f, const uint16_t *g, unsigned logn);
+
+/*
+ * Subtraction modulo q. Operands must be in the 0..q-1 range, as is
+ * the result.
+ */
+uint32_t Zf(mq_sub)(uint32_t x, uint32_t y);
+
 /* ==================================================================== */
 
 #endif

--- a/vrfy.c
+++ b/vrfy.c
@@ -631,15 +631,15 @@ mq_poly_sub(uint16_t *f, const uint16_t *g, unsigned logn)
 }
 
 // NTT functions exported for use in deterministic.h
-void Zf(mq_NTT)(uint16_t *a, unsigned logn)  { mq_NTT(a, logn); };
-void Zf(mq_iNTT)(uint16_t *a, unsigned logn) { mq_iNTT(a, logn); };
+void Zf(mq_NTT)(uint16_t *a, unsigned logn)  { mq_NTT(a, logn); }
+void Zf(mq_iNTT)(uint16_t *a, unsigned logn) { mq_iNTT(a, logn); }
 void Zf(mq_poly_montymul_ntt)(uint16_t *f, const uint16_t *g, unsigned logn) {
 	mq_poly_montymul_ntt(f, g, logn);
-};
+}
 void Zf(mq_poly_sub)(uint16_t *f, const uint16_t *g, unsigned logn) {
 	mq_poly_sub(f, g, logn);
-};
-uint32_t Zf(mq_sub)(uint32_t x, uint32_t y) { return mq_sub(x, y); };
+}
+uint32_t Zf(mq_sub)(uint32_t x, uint32_t y) { return mq_sub(x, y); }
 
 /* ===================================================================== */
 

--- a/vrfy.c
+++ b/vrfy.c
@@ -630,6 +630,17 @@ mq_poly_sub(uint16_t *f, const uint16_t *g, unsigned logn)
 	}
 }
 
+// NTT functions exported for use in deterministic.h
+void Zf(mq_NTT)(uint16_t *a, unsigned logn)  { mq_NTT(a, logn); };
+void Zf(mq_iNTT)(uint16_t *a, unsigned logn) { mq_iNTT(a, logn); };
+void Zf(mq_poly_montymul_ntt)(uint16_t *f, const uint16_t *g, unsigned logn) {
+	mq_poly_montymul_ntt(f, g, logn);
+};
+void Zf(mq_poly_sub)(uint16_t *f, const uint16_t *g, unsigned logn) {
+	mq_poly_sub(f, g, logn);
+};
+uint32_t Zf(mq_sub)(uint32_t x, uint32_t y) { return mq_sub(x, y); };
+
 /* ===================================================================== */
 
 /* see inner.h */


### PR DESCRIPTION
This adds auxiliary functions for extracting/computing various ring elements from public keys and signatures. We use them to compute the right "hints" (witnesses) for SNARK-friendly Falcon verification.