### PR TITLE
add -Wno-strict-prototypes to CFLAGS

### DIFF
--- a/falcon.go
+++ b/falcon.go
@@ -20,7 +20,7 @@ package falcon
 
 // NOTE: cgo go code couldn't compile with the flags: -Wmissing-prototypes and -Wno-unused-paramete
 
-//#cgo CFLAGS:  -Wall -Wextra -Wpedantic -Wredundant-decls -Wshadow -Wvla -Wpointer-arith -Wno-unused-parameter -Wno-overlength-strings  -O3 -fomit-frame-pointer
+//#cgo CFLAGS:  -Wall -Wextra -Wpedantic -Wredundant-decls -Wshadow -Wvla -Wpointer-arith -Wno-unused-parameter -Wno-overlength-strings  -O3 -fomit-frame-pointer -Wno-strict-prototypes
 // #include "falcon.h"
 // #include "deterministic.h"
 import "C"


### PR DESCRIPTION
This will silence warnings like:
```
# [github.com/algorand/falcon](http://github.com/algorand/falcon)
_cgo_main.c:2:9: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
```
On Mac with clang.