### PR TITLE
CI: add GHA build+test multi-platform workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-latest
+          - macos-15-intel
+          - windows-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build C tests
+        run: make
+      - name: Deterministic KAT tests
+        run: ./tests/test_deterministic
+      - name: Falcon tests
+        run: ./tests/test_falcon
+      - name: Speed smoke test
+        run: ./tests/speed 1
+      - name: Go tests
+        run: go test -v ./...

--- a/falcon_test.go
+++ b/falcon_test.go
@@ -3,14 +3,13 @@ package falcon
 import (
 	"bytes"
 	"crypto/rand"
+	"crypto/sha3"
 	"encoding/hex"
 	"fmt"
 	mathrand "math/rand"
 	"strings"
 	"testing"
 	"time"
-
-	"golang.org/x/crypto/sha3"
 )
 
 var kats = []string{
@@ -49,7 +48,7 @@ var kats = []string{
 }
 
 func testKAT(t *testing.T, msgLen int) {
-	msgrng := sha3.NewShake256()
+	msgrng := sha3.NewSHAKE256()
 	fmt.Fprintf(msgrng, "msg-%04d", msgLen)
 	msg := make([]byte, msgLen)
 	msgrng.Read(msg)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/algorand/falcon
 
-go 1.16
-
-require golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
+go 1.24

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,0 @@
-golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=
-golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
Runs C and Go tests on 5 platforms: Linux (x86, arm); Mac (x86, Apple Silicon); Windows.

Upgrades to Go 1.24 which fixes Windows cgo build error on the GHA runner, and also provides a builtin `crypto/sha3` used in `falcon_test.go` (so now this library has no Go package dependencies)